### PR TITLE
refactor: remove unnecessary clones when constructing notes

### DIFF
--- a/clob_tools/src/notes/mod.rs
+++ b/clob_tools/src/notes/mod.rs
@@ -39,7 +39,7 @@ pub fn create_p2id_note(
     let metadata = NoteMetadata::new(sender, note_type, tag, NoteExecutionHint::always(), aux)?;
     let vault = NoteAssets::new(assets)?;
 
-    let recipient = NoteRecipient::new(serial_num.into(), note_script, inputs.clone());
+    let recipient = NoteRecipient::new(serial_num.into(), note_script, inputs);
 
     Ok(Note::new(vault, metadata, recipient))
 }

--- a/clob_tools/src/swap/operations.rs
+++ b/clob_tools/src/swap/operations.rs
@@ -69,8 +69,8 @@ pub fn create_partial_swap_note(
     )?;
 
     let assets = NoteAssets::new(vec![offered_asset])?;
-    let recipient = NoteRecipient::new(swap_serial_num.into(), note_script.clone(), inputs.clone());
-    let note = Note::new(assets.clone(), metadata, recipient.clone());
+    let recipient = NoteRecipient::new(swap_serial_num.into(), note_script, inputs);
+    let note = Note::new(assets, metadata, recipient);
 
     Ok(note)
 }
@@ -142,8 +142,8 @@ pub fn create_partial_swap_note_cancellable(
     )?;
 
     let assets = NoteAssets::new(vec![offered_asset])?;
-    let recipient = NoteRecipient::new(swap_serial_num.into(), note_script.clone(), inputs.clone());
-    let note = Note::new(assets.clone(), metadata, recipient.clone());
+    let recipient = NoteRecipient::new(swap_serial_num.into(), note_script, inputs.clone());
+    let note = Note::new(assets, metadata, recipient);
 
     println!(
         "inputlen: {:?}, NoteInputs: {:?}",


### PR DESCRIPTION
Removed redundant clone calls when building NoteRecipient and Note in the swap and notes helpers. Now pass ownership of NoteScript, NoteInputs and NoteAssets directly into NoteRecipient::new and Note::new, avoiding extra allocations and copies. The behavior of note creation remains unchanged, but the implementation is leaner and consistent with other note helpers in the codebase.